### PR TITLE
Bump Dependencies (usvg, piet, kurbo) eliminate some duplicates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,4 @@
 resolver = "2"
 members = ["druid", "druid-shell", "druid-derive"]
 default-members = ["druid", "druid-shell", "druid-derive"]
+

--- a/druid-derive/Cargo.toml
+++ b/druid-derive/Cargo.toml
@@ -15,12 +15,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
-syn = "1.0.39"
-quote = "1.0.7"
-proc-macro2 = "1.0.19"
+syn = "1.0"
+quote = "1.0"
+proc-macro2 = "1.0"
 
 [dev-dependencies]
 druid = { version = "0.7.0", path = "../druid" }
 trybuild = "1.0"
 
-float-cmp = { version = "0.8.0", features = ["std"], default-features = false }
+float-cmp = { version = "0.8", features = ["std"], default-features = false }

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -41,8 +41,8 @@ serde = ["kurbo/serde"]
 copypasta = "0.7.1"
 piet-wgpu = { git = "https://github.com/lapce/piet-wgpu" }
 winit = { git = "https://github.com/lapce/winit", branch = "new-keyboard-all" }
-# piet-common = "=0.5.0-pre1"
-kurbo = "0.8.1"
+# piet-common = "0.5.0"
+kurbo = "0.8.3"
 
 tracing = "0.1.22"
 lazy_static = "1.4.0"
@@ -73,7 +73,7 @@ features = [
 ]
 
 [dev-dependencies]
-piet-common = { version = "=0.5.0-pre1", features = ["png"] }
+piet-common = { version = "0.5.0", features = ["png"] }
 static_assertions = "1.1.0"
 test-env-log = { version = "0.2.5", features = [
         "trace",

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -68,40 +68,40 @@ winit = { git = "https://github.com/lapce/winit", branch = "new-keyboard-all" }
 druid-shell = { version = "0.7.0", default-features = false, path = "../druid-shell" }
 druid-derive = { version = "0.4.0", path = "../druid-derive" }
 
-tracing = { version = "0.1.22" }
-tracing-subscriber = { version = "0.2.15", features = [
+tracing = { version = "0.1.32" }
+tracing-subscriber = { version = "0.3.9", features = [
 	"fmt",
 	"ansi",
 ], default-features = false }
-fluent-bundle = "0.15.1"
+fluent-bundle = "0.15.2"
 fluent-langneg = "0.13.0"
 fluent-syntax = "0.11.0"
 unic-langid = "0.9.0"
-unicode-segmentation = "1.6.0"
+unicode-segmentation = "1.9.0"
 xi-unicode = "0.3.0"
 fnv = "1.0.7"
-instant = { version = "0.1.6", features = ["wasm-bindgen"] }
+instant = { version = "0.1.12", features = ["wasm-bindgen"] }
 
 # Optional dependencies
 chrono = { version = "0.4.19", optional = true }
-im = { version = "15.0.0", optional = true }
-usvg = { version = "0.14.1", optional = true }
+im = { version = "15.0", optional = true }
+usvg = { version = "0.22", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
-tracing-wasm = { version = "0.2.0" }
-console_error_panic_hook = { version = "0.1.6" }
+tracing-wasm = { version = "0.2.1" }
+console_error_panic_hook = { version = "0.1.7" }
 
 [dev-dependencies]
-float-cmp = { version = "0.8.0", features = ["std"], default-features = false }
+float-cmp = { version = "0.9.0", features = ["std"], default-features = false }
 # tempfile 3.2.0 broke wasm; I assume it will be yanked (Jan 12, 2021)
 tempfile = "=3.1.0"
-piet-common = { version = "=0.5.0-pre1", features = ["png"] }
-pulldown-cmark = { version = "0.8", default-features = false }
-test-env-log = { version = "0.2.5", features = [
+piet-common = { version = "0.5.0", features = ["png"] }
+pulldown-cmark = { version = "0.9", default-features = false }
+test-env-log = { version = "0.2.8", features = [
 	"trace",
 ], default-features = false }
 # test-env-log needs it
-tracing-subscriber = { version = "0.2.15", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 
 [target.'cfg(not(target_arch="wasm32"))'.dev-dependencies]
 open = "1.6"

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -129,7 +129,7 @@ impl SvgData {
         "###;
 
         SvgData {
-            tree: Arc::new(usvg::Tree::from_str(empty_svg, &re_opt).unwrap()),
+            tree: Arc::new(usvg::Tree::from_str(empty_svg, &re_opt.to_ref()).unwrap()),
         }
     }
 
@@ -213,7 +213,7 @@ impl FromStr for SvgData {
 
         re_opt.fontdb.load_system_fonts();
 
-        match usvg::Tree::from_str(svg_str, &re_opt) {
+        match usvg::Tree::from_str(svg_str, &re_opt.to_ref()) {
             Ok(tree) => Ok(SvgData {
                 tree: Arc::new(tree),
             }),


### PR DESCRIPTION
This goes in tandem with the associated PRs:

piet-wgpu: https://github.com/lapce/piet-wgpu/pull/5
lapce: https://github.com/lapce/lapce/pull/310