### PR TITLE
On Windows moves the resizing borders when the title bar is disabled

### DIFF
--- a/druid-shell/src/backend/windows/window.rs
+++ b/druid-shell/src/backend/windows/window.rs
@@ -960,17 +960,20 @@ impl WndProc for MyWndProc {
             WM_NCCALCSIZE => unsafe {
                 if wparam != 0 && !self.has_titlebar() {
                     if let Ok(handle) = self.handle.try_borrow() {
-                        if handle.get_window_state() == window::WindowState::Maximized {
-                            // When maximized, windows still adds offsets for the frame
-                            // so we counteract them here.
-                            let s: *mut NCCALCSIZE_PARAMS = lparam as *mut NCCALCSIZE_PARAMS;
-                            if let Some(mut s) = s.as_mut() {
-                                let border = self.get_system_metric(SM_CXPADDEDBORDER);
-                                let frame = self.get_system_metric(SM_CYSIZEFRAME);
+                        let s: *mut NCCALCSIZE_PARAMS = lparam as *mut NCCALCSIZE_PARAMS;
+                        if let Some(mut s) = s.as_mut() {
+                            let border = self.get_system_metric(SM_CXPADDEDBORDER);
+                            let frame = self.get_system_metric(SM_CYSIZEFRAME);
+                            // When the window does not have a title bar, the location of the
+                            // resizing borders moves inside the window, so we subtract them
+                            // from it
+                            s.rgrc[0].right -= (border + frame) as i32;
+                            s.rgrc[0].left += (border + frame) as i32;
+                            s.rgrc[0].bottom -= (border + frame) as i32;
+                            if handle.get_window_state() == window::WindowState::Maximized {
+                                // When maximized, windows still adds offsets for the frame
+                                // so we counteract them here.
                                 s.rgrc[0].top += (border + frame) as i32;
-                                s.rgrc[0].right -= (border + frame) as i32;
-                                s.rgrc[0].left += (border + frame) as i32;
-                                s.rgrc[0].bottom -= (border + frame) as i32;
                             }
                         }
                     }


### PR DESCRIPTION
On the Lapce repository this issue https://github.com/lapce/lapce/issues/1572 has been raised and it is due to the fact that the resizing borders are placed differently on windows without borders. This can be illustrated by the following image:  

![80299754-5cd9e880-87b0-11ea-9e84-4c21aac05a8f](https://user-images.githubusercontent.com/101042422/197380767-d63350bb-4c58-492b-bcd0-3213a164a42e.png)

So I solve this problem, on Windows, by manually subtracting the resizing borders from the window size so that they are in the same place as on a classic window