### PR TITLE
Fix bring to front on mac not going over current active window

### DIFF
--- a/druid-shell/src/backend/mac/window.rs
+++ b/druid-shell/src/backend/mac/window.rs
@@ -1237,6 +1237,7 @@ impl WindowHandle {
     pub fn bring_to_front_and_focus(&self) {
         unsafe {
             let window: id = msg_send![*self.nsview.load(), window];
+            let () = msg_send![NSApp(), performSelectorOnMainThread: sel!(activateIgnoringOtherApps:) withObject: YES waitUntilDone: NO];
             let () = msg_send![window, performSelectorOnMainThread: sel!(makeKeyAndOrderFront:) withObject: nil waitUntilDone: NO];
         }
     }


### PR DESCRIPTION
Currently in MacOS if you open a file/directory from terminal and lapce is already opened, lapce stays behind the terminal.
Using this fix lapce goes to the front of the terminal as expected.