### PR TITLE
link https://github.com/lapce/lapce/issues/2143

### DIFF
--- a/druid-shell/src/gl.rs
+++ b/druid-shell/src/gl.rs
@@ -209,7 +209,7 @@ impl Default for PixelFormatRequirements {
             double_buffer: None,
             multisampling: None,
             stereoscopy: false,
-            srgb: true,
+            srgb: false,
             release_behavior: ReleaseBehavior::Flush,
             x11_visual_xid: None,
         }


### PR DESCRIPTION
When lapce starts running, it checks the environment for WGL_ARB_framebuffer_sRGB or WGL_EXT_framebuffer_sRGB, and if not, and the requested srgb is true, it panic. So although srgb is not required, as long as the above two extensions are not available in the system environment, the program will panic.
In hyper-v，we can't find WGL_ARB_framebuffer_sRGB and WGL_EXT_framebuffer_sRGB，so it exited and caused the ucrt 0xc0000409 error.